### PR TITLE
Switch back to foldlevel=99 instead of zR

### DIFF
--- a/xdg_config/nvim/init.lua
+++ b/xdg_config/nvim/init.lua
@@ -68,13 +68,7 @@ vim.cmd([[
 vim.opt.mouse = "ar"
 
 vim.opt.foldmethod = "indent"
-vim.cmd([[
-    augroup autoset_foldlevel
-        autocmd!
-        " Set fold level to max foldlevel of buffer when added to window
-        autocmd BufWinEnter * normal zR
-    augroup END
-]])
+vim.opt.foldlevel = 99
 
 -- Autoload files from disk
 vim.opt.autoread = true


### PR DESCRIPTION
The zR thing caused random issues and I don't use the keybinds that adjust the foldlevel by 1.