### PR TITLE
Add command to quickly install all packages for a type of dev environ…

### DIFF
--- a/xdg_config/fish/functions/devenv.fish
+++ b/xdg_config/fish/functions/devenv.fish
@@ -1,0 +1,30 @@
+function devenv
+    set -l env $argv[1]
+    if [ -z "$env" ]
+        if [ -e pyproject.toml ]
+            set env python
+        else if [ -d xdg_config ]
+            set env lua
+        else
+            set env base
+        end
+    end
+
+
+    set -l packages bat delta exa fd nvim rg
+    switch $env
+        case go
+            set -a packages gopls
+        case lua
+            set -a packages lua_ls
+        case python
+            set -a packages pyright debugpy
+    end
+
+    if [ -e .pre-commit-config.yaml ]
+        set -a packages pre-commit
+    end
+
+    printf "Installing packages for the %s$env%s environment (%s$packages%s)\n" (set_color green) (set_color normal) (set_color yellow) (set_color normal)
+    cmd_install $packages
+end


### PR DESCRIPTION
…ment

Currently when I start a codespace I have to type out all the packages that I want to install. It isn't that much work, but remembering all of them is a bit annoying and I tend to forget one or two. This accepts the type of environment as the first arg or try to detect it based on the files in the directory and then installs a pre-configured set of packages.