### PR TITLE
Add IblScope highlight

### DIFF
--- a/xdg_config/nvim/lua/plugins.lua
+++ b/xdg_config/nvim/lua/plugins.lua
@@ -34,6 +34,11 @@ require("lazy").setup({
                     comments = "italic",
                 },
             },
+            groups = {
+                all = {
+                    IblScope = { fg = "palette.blue" },
+                },
+            },
         },
     },
 


### PR DESCRIPTION
The default was bright yellow and that is a bit too distracting.