### PR TITLE
Fix terminal exit mapping of ctrl--

### DIFF
--- a/xdg_config/nvim/init.lua
+++ b/xdg_config/nvim/init.lua
@@ -189,7 +189,7 @@ noremap("<leader>vs", "<cmd>vs<CR>", { silent = true })
 noremap("<leader>bh", "<cmd>hide<CR>", { silent = true })
 
 -- Terminal mappings
-tnoremap("<c-_>", "<c-\\><c-n>")
+tnoremap("<c-->", "<c-\\><c-n>")
 vim.cmd([[
     augroup vimrcterminal
         autocmd!


### PR DESCRIPTION
I had it as ctrl-_ and ctrl-- worked, but with ghostty I need to set it to the correct thing.