### PR TITLE
Cleanup more copilot related things

### DIFF
--- a/xdg_config/cmd_install/config.toml
+++ b/xdg_config/cmd_install/config.toml
@@ -271,10 +271,6 @@ packages = ["vscode-langservers-extracted"]
 type = "npm_global"
 packages = ["opencode-ai@latest"]
 
-[commands.copilot-language-server]
-type = "npm_global"
-packages = ["@github/copilot-language-server"]
-
 [commands.gopls]
 type = "go_install"
 package = "golang.org/x/tools/gopls@latest"

--- a/xdg_config/fish/functions/devenv.fish
+++ b/xdg_config/fish/functions/devenv.fish
@@ -12,7 +12,7 @@ function devenv
         end
     end
 
-    set -l packages bat delta eza fd nvim rg copilot-language-server
+    set -l packages bat delta eza fd nvim rg
     switch $env
         case go
             set -a packages gopls

--- a/xdg_config/nvim/lazy-lock.json
+++ b/xdg_config/nvim/lazy-lock.json
@@ -1,5 +1,4 @@
 {
-  "blink-copilot": { "branch": "main", "commit": "7ad8209b2f880a2840c94cdcd80ab4dc511d4f39" },
   "blink.cmp": { "branch": "main", "commit": "4b18c32adef2898f95cdef6192cbd5796c1a332d" },
   "conform.nvim": { "branch": "master", "commit": "40dcec5555f960b0a04340d76eabdf4efe78599d" },
   "everforest-nvim": { "branch": "main", "commit": "557bce922401e247a596583679bc181d4d688554" },

--- a/xdg_config/nvim/lua/plugins/llm.lua
+++ b/xdg_config/nvim/lua/plugins/llm.lua
@@ -2,34 +2,16 @@ return {
 
     {
         "folke/sidekick.nvim",
-        opts = {},
+        opts = {
+            nes = { enabled = false },
+        },
         keys = {
-            {
-                "<tab>",
-                function()
-                    -- if there is a next edit, jump to it, otherwise apply it if any
-                    if not require("sidekick").nes_jump_or_apply() then
-                        return "<Tab>" -- fallback to normal tab
-                    end
-                end,
-                expr = true,
-                desc = "Goto/Apply Next Edit Suggestion",
-            },
             {
                 "<leader>aa",
                 function()
                     require("sidekick.cli").toggle({ name = vim.g.sidekick_cli or "opencode", focus = true })
                 end,
                 desc = "Sidekick Toggle CLI",
-            },
-            {
-                "<leader>as",
-                function()
-                    require("sidekick.cli").select()
-                end,
-                -- Or to select only installed tools:
-                -- require("sidekick.cli").select({ filter = { installed = true } })
-                desc = "Select CLI",
             },
             {
                 "<leader>at",

--- a/xdg_config/nvim/lua/plugins/lsp.lua
+++ b/xdg_config/nvim/lua/plugins/lsp.lua
@@ -21,7 +21,6 @@ return {
             -- Use a loop to conveniently both setup defined servers
             -- and map buffer local keybindings when the language server attaches
             local servers = {
-                copilot = {},
                 cssls = {},
                 gopls = {
                     gopls = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenCode to the environment’s global package installation.

- **Changes**
  - Removed Copilot language-server from the default setup and disabled Copilot in Neovim’s LSP configuration.
  - Removed the related Copilot Neovim plugin lock entry.
  - Updated Sidekick configuration to disable `nes` and adjusted its keybindings (removed some mappings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->