### PR TITLE
Install jj and opencode by default and remove conflict x from fish prompt

### DIFF
--- a/xdg_config/fish/functions/devenv.fish
+++ b/xdg_config/fish/functions/devenv.fish
@@ -12,7 +12,7 @@ function devenv
         end
     end
 
-    set -l packages bat delta eza fd nvim rg
+    set -l packages bat delta eza fd nvim rg jj opencode
     switch $env
         case go
             set -a packages gopls

--- a/xdg_config/fish/functions/fish_jj_prompt.fish
+++ b/xdg_config/fish/functions/fish_jj_prompt.fish
@@ -49,15 +49,6 @@ function fish_jj_prompt
             set ahead_count (count $ahead_entries)
         end
     end
-
-    # Check for conflicts on the working copy commit
-    set -l conflict_flag (jj log --no-graph --ignore-working-copy --color=never --revisions @ \
-        --template 'if(conflict, "1", "")' 2>/dev/null)
-    set -l has_conflicts 0
-    if test -n (string trim -- $conflict_flag)
-        set has_conflicts 1
-    end
-
     printf '('
 
     set_color brwhite
@@ -97,12 +88,6 @@ function fish_jj_prompt
     if test $ahead_count -gt 0
         set_color yellow
         printf ' ↑%s' $ahead_count
-        set_color normal
-    end
-
-    if test $has_conflicts -eq 1
-        set_color red
-        printf ' ×'
         set_color normal
     end
 


### PR DESCRIPTION
I basically always use jj and use opencode most of the time, so install them by default. The in prompt conflict marker wasn't working correctly and I don't think I really need it, so I am just removing it.