### PR TITLE
Add opencode alias

### DIFF
--- a/xdg_config/fish/conf.d/abbrs.fish
+++ b/xdg_config/fish/conf.d/abbrs.fish
@@ -18,6 +18,10 @@ function update_abbrs
         abbr -ga cat 'bat -p'
     end
 
+    if command -qs opencode
+        abbr -ga oc opencode
+    end
+
     if command -qs nvim
         abbr -ga edit nvim
     else


### PR DESCRIPTION
I have this setup for work and keep trying to run it on my personal computer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `oc` Fish shell abbreviation for quickly launching `opencode` when it is installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->